### PR TITLE
Use HTTPS to install in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@
 Download [zplug](https://git.io/zplug) and put it in `~/.zplug`
 
 ```console
-$ curl -fLo ~/.zplug/zplug --create-dirs git.io/zplug
+$ curl -fLo ~/.zplug/zplug --create-dirs https://git.io/zplug
 ```
 
 ## Usage


### PR DESCRIPTION
Piping scripts delivered over HTTP into your shell opens you up to MITM attacks. HTTPS prevents it.