### PR TITLE
Fix parsing of git version string on OS X

### DIFF
--- a/zplug
+++ b/zplug
@@ -222,7 +222,7 @@ __version_requirement() {
 }
 
 __git_version() {
-    __version_requirement "${${(z)"$(git --version)"}[-1]}" "$@"
+    __version_requirement "${${(z)"$(git --version | cut -d\( -f1)"}[-1]}" "$@"
     return $status
 }
 


### PR DESCRIPTION
Apple of course has their own way of setting versions for software;

  git --version
  git version 2.4.9 (Apple Git-60)

After this change, everything from the first ( is removed. Fixes #39.