### PR TITLE
Fix nices sorting

### DIFF
--- a/zplug
+++ b/zplug
@@ -742,7 +742,7 @@ __zplug::load()
         nices+=("$zspec[nice]:$zspec[name]")
     done
 
-    for key in ${${(on)nices}#*:}
+    for key in ${${(OnM)nices:#-*}#*:} ${${(on)nices:#-*}#*:}
     do
         zspec=( ${(@f)"$(__zplug::parser "$key")"} )
         for k in ${(k)zspec}


### PR DESCRIPTION
`${${(on)nices}#*:}` doesn't sort `nice` correctly since zsh doesn't recognize minus sign as a part of numbers.