### PR TITLE
Fix sleep(1) argument for BSD

### DIFF
--- a/zplug
+++ b/zplug
@@ -350,7 +350,7 @@ __bg_rotation_bar() {
             2) echo -ne " -\r";;
             3) echo -ne " \\\\\r";;
         esac
-        sleep 0.05s
+        sleep 0.05
     done
 }
 


### PR DESCRIPTION
On *BSD, the `sleep(1)` command's argument does not allow a unit suffix. The default unit on Linux is seconds anyway, so it's safe to omit.