### PR TITLE
Suppress "not loaded" message unless --verbose

### DIFF
--- a/zplug
+++ b/zplug
@@ -862,13 +862,13 @@ __zplug::load()
             fi
             if [[ -n $zspec[if] ]]; then
                 if ! eval "$zspec[if]" >/dev/null 2>&1; then
-                    __die "$zspec[name]: (not load)\n"
+                    __die "$zspec[name]: (not loaded)\n"
                     continue
                 fi
             fi
             if [[ -n $zspec[on] ]]; then
                 if ! [[ -e $ZPLUG_HOME/repos/$zspec[on] ]]; then
-                    __die "$zspec[name]: (not load)\n"
+                    __die "$zspec[name]: (not loaded)\n"
                     continue
                 fi
             fi

--- a/zplug
+++ b/zplug
@@ -862,13 +862,13 @@ __zplug::load()
             fi
             if [[ -n $zspec[if] ]]; then
                 if ! eval "$zspec[if]" >/dev/null 2>&1; then
-                    __die "$zspec[name]: (not loaded)\n"
+                    $is_verbose && __die "$zspec[name]: (not loaded)\n"
                     continue
                 fi
             fi
             if [[ -n $zspec[on] ]]; then
                 if ! [[ -e $ZPLUG_HOME/repos/$zspec[on] ]]; then
-                    __die "$zspec[name]: (not loaded)\n"
+                    $is_verbose && __die "$zspec[name]: (not loaded)\n"
                     continue
                 fi
             fi


### PR DESCRIPTION
I made this change because I think it makes more sense to show the plugins that were **not** loaded only when `--verbose` was used, just like how it is currently for plugins that **were** loaded.