### PR TITLE
Remove the username directory if empty after removal of plugin

### DIFF
--- a/zplug
+++ b/zplug
@@ -1611,6 +1611,7 @@ __zplug::clean()
         __put "Remove really? [y/N]: "
         if $is_force || read -q; then
             command rm -rf "${(u)remove_args[@]}"
+            command rmdir "${(u)remove_args[@]:h}" 2>/dev/null
             clean_deadlinks
             __put "\nRemoved\n"
         else
@@ -1640,6 +1641,7 @@ __zplug::clean()
         __put "Remove? [y/N]: "
         if $is_force || read -q; then
             command rm -rf "${repos[@]}"
+            command rmdir "${repos[@]:h}" 2>/dev/null
             clean_deadlinks
             __put "\nRemoved\n"
         else


### PR DESCRIPTION
I found there are some empty directories after removing some plugins.

This prevents `$ZPLUG_HOME/repos` from being cluttered with empty username
directories.