### PR TITLE
Use HEAD instead of @ and fetch --unshallow on update. Closes #79

### DIFF
--- a/zplug
+++ b/zplug
@@ -550,15 +550,15 @@ __zplug::update()
                 else
                     local fetch_opt
                     if [[ -e $zspec[dir]/.git/shallow ]]; then
-                        fetch_opt='--depth 99999999'
+                        fetch_opt='--unshallow'
                     fi
                     git fetch $fetch_opt
                     git checkout -q $zspec[at]
 
                     local rev_local rev_remote rev_base
-                    rev_local=$(git rev-parse @)
+                    rev_local=$(git rev-parse HEAD)
                     rev_remote=$(git rev-parse "@{u}")
-                    rev_base=$(git merge-base @ "@{u}")
+                    rev_base=$(git merge-base HEAD "@{u}")
 
                     if [[ $rev_local == $rev_remote ]]; then
                         # up-to-date


### PR DESCRIPTION
See #79.

```zsh
agross@router ~
$ zplug update
Updating...  zsh-users/zsh-syntax-highlighting
Updating...  rhysd/zsh-bundle-exec
Updating...  agross/rapid-git
Updating...  b4b4r07/zplug
Updating...  bobthecow/git-flow-completion
Updating...  plugins/ssh-agent
Updating...  holman/dotfiles
Up-to-date   rhysd/zsh-bundle-exec              (1.11s)
Up-to-date   b4b4r07/zplug                      (1.15s)
Up-to-date   zsh-users/zsh-syntax-highlighting  (1.38s)
Up-to-date   bobthecow/git-flow-completion      (1.38s)
Up-to-date   holman/dotfiles                    (1.41s)
Updated!     agross/rapid-git                   (1.60s)
Up-to-date   plugins/ssh-agent                  (1.99s)
[4]    27549 done       { trap  INT; local k bg_pid ret=1; local -A zspec; zspec=() ; for k in ; do;
[6]  - 27554 done       { trap  INT; local k bg_pid ret=1; local -A zspec; zspec=() ; for k in ; do;
[10]  + 27573 done       { trap  INT; local k bg_pid ret=1; local -A zspec; zspec=() ; for k in ; do;
```

I don't know what these `trap INT` lines are supposed to say, but at least the update was made.