### PR TITLE
Suppress no matches found error

### DIFF
--- a/zplug
+++ b/zplug
@@ -1593,7 +1593,7 @@ __zplug::clean()
 
     clean_deadlinks() {
         local link
-        for link in $ZPLUG_HOME/bin/*(@)
+        for link in $ZPLUG_HOME/bin/*(@N)
         do
             if [[ -L $link ]] && [[ ! -e $link ]]; then
                 command rm -f "$link"


### PR DESCRIPTION
When I run `zplug clean` with no longer managed repositories and there is no deadlinks under `$ZPLUG_HOME/bin/`, an error message is displayed.

```
$ zplug clean
These repositories are no longer managed by zplug.
- ~/.zplug/repos/robbyrussell/oh-my-zsh
Remove? [y/N]: yclean_deadlinks:2: no matches found: ~/.zplug/bin/*(@)
```

So this pull request sets `null_glob` option temporarily in `clean_deadlinks()`, which is explained on [16.2.3 Expansion and Globbing](http://zsh.sourceforge.net/Doc/Release/Options.html#Description-of-Options):

> NULL_GLOB (-G)
>
> If a pattern for filename generation has no matches, delete the pattern from the argument list instead of reporting an error. Overrides NOMATCH.