### PR TITLE
Fix version check of git

### DIFF
--- a/zplug
+++ b/zplug
@@ -310,7 +310,7 @@ __version_requirement() {
 }
 
 __git_version() {
-    __version_requirement "${(M)${(z)"$(git --version)"}:#[0-9]*[0-9]} " "$@"
+    __version_requirement ${(M)${(z)"$(git --version)"}:#[0-9]*[0-9]} "$@"
     return $status
 }
 


### PR DESCRIPTION
I tested with GNU grep 2.21 and BSD grep 2.5.1.

Issue #102. This bug is caused by `__version_requirement` expecting a string
that consists of digits and periods but `git --version` outputs a string in
the form `git version X.Y.Z`.