### PR TITLE
Fix compinit to reproduce zcompdump when completion files change

### DIFF
--- a/zplug
+++ b/zplug
@@ -1077,7 +1077,7 @@ __zplug::load()
     done
     # NOTE: set fpath before compinit
     fpath=(${(u)load_fpaths} $fpath)
-    compinit -C -d "$ZPLUG_HOME/zcompdump"
+    compinit -i -d "$ZPLUG_HOME/zcompdump"
 
     for f in ${nice_plugins[@]}
     do
@@ -1115,7 +1115,7 @@ __zplug::load()
         fi
         __put '\n# fpath\n'
         __put 'fpath=(%s $fpath)\n' "${(u)load_fpaths}"
-        __put 'compinit -C -d %s\n' "$ZPLUG_HOME/zcompdump"
+        __put 'compinit -i -d %s\n' "$ZPLUG_HOME/zcompdump"
         if (( $#nice_plugins > 0 )); then
             __put '\n# Loading after compinit\n'
             __put 'source %s\n' "${(qqq)nice_plugins[@]}"


### PR DESCRIPTION
Related to #44.

`-C` option skips security checks entirely, and the dump file will only be created if there isn't one already. If we change `-C` to `-i`, then `compinit` will recognize the changes of completion files and produce a new dump file.

See http://zsh.sourceforge.net/Doc/Release/Completion-System.html#Use-of-compinit for details.

# Problem

Actually I use [zsh-users/zsh-completions](https://github.com/zsh-users/zsh-completions) for completions, and it recently removed brew completion at https://github.com/zsh-users/zsh-completions/commit/173ae7249a6ab4a5b70bebb283f3f156eb79f908. When I run `zplug update` and open a new shell, `brew <Tab>` raises error like:

```
(eval):1: _brew: function definition file not found
(eval):1: _brew: function definition file not found
(eval):1: _brew: function definition file not found
```

# Reproducing

I've tested with:

``` zsh
source $HOME/.zplug/zplug

zplug "b4b4r07/zplug"
zplug "zsh-users/zsh-completions"

if ! zplug check; then
  zplug install
fi
zplug load
```

Open a new shell, then run following commands:

``` sh
cd ~/.zplug/repos/zsh-users/zsh-completions
git checkout 173ae72~
rm .zplug/zcompdump .zplug/.cache .zcompdump
```

Exit and open a new shell, then zcompdump files will be generated with `_brew` of `zsh-users/zsh-completions`. Then checkout `zsh-users/zsh-completions` to the version of which don't have `_brew`:

``` sh
cd ~/.zplug/repos/zsh-users/zsh-completions
git checkout 173ae72
```

Exit and open a new shell, then zcompdump won't update, at least for `_brew`, which makes `brew <Tab>` raise an error.