### PR TITLE
Fixed the wrong behavior of `do tag`

### DIFF
--- a/zplug
+++ b/zplug
@@ -1790,6 +1790,7 @@ TEMPLATE
 }
 
 zplug() {
+    setopt localoptions noshwordsplit
     local arg
     arg="$1"
 


### PR DESCRIPTION
Fixed #110 .

Added disabling shwordsplit with localoptions.