### PR TITLE
Remove `setopt localoptions`

### DIFF
--- a/zplug
+++ b/zplug
@@ -754,11 +754,11 @@ __zplug::install()
             # send a http request to git.io/releases with os argument
             # or, git clone (case of normal plugin)
             __zplug::clone \
-                --of ${zspec[of]:-""} \
-                --commit ${zspec[commit]:-""} \
-                --from ${zspec[from]:-""} \
-                --at ${zspec[at]:-""} \
-                --do ${zspec[do]:-""} \
+                --of "${zspec[of]:-""}" \
+                --commit "${zspec[commit]:-""}" \
+                --from "${zspec[from]:-""}" \
+                --at "${zspec[at]:-""}" \
+                --do "${zspec[do]:-""}" \
                 "$line"
             ret=$status
 
@@ -1790,7 +1790,6 @@ TEMPLATE
 }
 
 zplug() {
-    setopt localoptions noshwordsplit
     local arg
     arg="$1"
 


### PR DESCRIPTION
The `setopt localoptions` inside the `zplug()` function reverts any change made by any other plugins or themes. This is caused by #111, and the problem of #110 can be solved by quoting arguments of `__zplug::clone` function.

I tested with this `.zshrc`:

``` zsh
setopt shwordsplit

source $HOME/.zplug/zplug

zplug "b4b4r07/hello_bitbucket", \
    as:command, \
    from:bitbucket, \
    do:"chmod 755 *.sh", \
    of:"*.sh"
zplug "yous/lime"

zplug check || zplug install
zplug load
```

Note that `yous/lime` [calls `setopt prompt_subst`](https://github.com/yous/lime/blob/master/lime.plugin.zsh) to enable parameter expansion, but `zplug()` reverts that after `zplug load`, prompt will display only `$(prompt_lime_render)`.

With this patch, zplug installs `b4b4r07/hello_bitbucket` with no error messages and the chmod of `hello.sh` has changed to 755. Also `setopt` will include `prompt_subst`.