### PR TITLE
Automatically set executable permissions on commands

### DIFF
--- a/zplug
+++ b/zplug
@@ -1088,7 +1088,7 @@ __zplug::load()
     # Commands
     for f in ${(k)load_commands}
     do
-        [[ -f $f ]] && ln -snf "$f" "$load_commands[$f]"
+        [[ -f $f ]] && { chmod a=rx "$f" && ln -snf "$f" "$load_commands[$f]"}
     done
     path=("$ZPLUG_HOME/bin" $path)
     typeset -gx -U path


### PR DESCRIPTION
Avoid having to have `do:"chmod a=rx *"` on every `as:command` entry.

Signed-off-by: Daniel Bayley <daniel.bayley@me.com>