### PR TITLE
Fix loading getting stuck in __zplug::support::omz::depends

### DIFF
--- a/lib/support/omz.zsh
+++ b/lib/support/omz.zsh
@@ -33,7 +33,7 @@ __zplug::support::omz::depends() {
         do
             [[ -f $t ]] || continue
             sed '/^ *#/d' "$t" \
-                | egrep "(^|\s|['\"(\`])$lib_f($|\s|[\\\\'\")\`])"
+                | egrep "(^|\s|['\"(\`])$lib_f($|\s|[\\\\'\")\`])" \
                 &>/dev/null &&
                 depends+=( "$omz_libs[$lib_f]" )
         done


### PR DESCRIPTION
This is caused by `&>/dev/null` being separated from the next command, and waits
on EOF from stdin.

## Steps to Reproduce

1. Run the following:

```console
$ __zplug::support::omz::depends 'plugins/golang'
```