### PR TITLE
Rename rename_to to rename-to

### DIFF
--- a/autoload/commands/__load__
+++ b/autoload/commands/__load__
@@ -122,7 +122,7 @@ do
             else
                 basename="${zspec[name]:t}"
                 zspec[dir]="${zspec[dir]%/}"
-                dst=${${zspec[rename_to]:+$ZPLUG_HOME/bin/$zspec[rename_to]}:-"$ZPLUG_HOME/bin"}
+                dst=${${zspec[rename-to]:+$ZPLUG_HOME/bin/$zspec[rename-to]}:-"$ZPLUG_HOME/bin"}
 
                 # Add parent directories to fpath if any files starting in _* exist
                 load_fpaths+=(${zspec[dir]}{_*,/**/_*}(N-.:h))

--- a/autoload/tags/__rename-to__
+++ b/autoload/tags/__rename-to__
@@ -11,9 +11,9 @@ local    default=""
 package="${arg}, ${zplugs[$arg]%, }"
 parsed_zplugs=(${(s/, /)package/,  */, })
 
-rename_to="${parsed_zplugs[(k)rename_to:*]#rename_to:*}"
+rename_to="${parsed_zplugs[(k)rename-to:*]#rename-to:*}"
 if [[ -z $rename_to ]]; then
-    zstyle -s ":zplug:tag" rename_to rename_to
+    zstyle -s ":zplug:tag" rename-to rename_to
 fi
 
 echo "${rename_to:-$default}"

--- a/autoload/utils/__add__
+++ b/autoload/utils/__add__
@@ -62,9 +62,9 @@ do
                 __zplug::print::print::die "Please use '$fg[blue]use$reset_color' tag instead ($fg[green]${name:gs:@::}$reset_color).\n"
                 ;;
             "file")
-                key="rename_to"
+                key="rename-to"
                 __zplug::print::print::die "[zplug] $fg[red]${(%):-"%U"}WARNING${(%):-"%u"}$reset_color: '$fg[blue]file$reset_color' tag is deprecated. "
-                __zplug::print::print::die "Please use '$fg[blue]rename_to$reset_color' tag instead ($fg[green]${name:gs:@::}$reset_color).\n"
+                __zplug::print::print::die "Please use '$fg[blue]rename-to$reset_color' tag instead ($fg[green]${name:gs:@::}$reset_color).\n"
                 ;;
             "commit")
                 key="at"

--- a/doc/man/man1/zplug.1
+++ b/doc/man/man1/zplug.1
@@ -411,7 +411,7 @@ at:v1\&.5\&.6
 T}
 T{
 .sp
-\fBrename_to\fR
+\fBrename-to\fR
 T}:T{
 .sp
 Specify the filename you want to rename to (only valid with as:command)
@@ -420,7 +420,7 @@ T}:T{
 \fBfilename\fR (\-)
 T}:T{
 .sp
-rename_to:fzf
+rename-to:fzf
 T}
 T{
 .sp
@@ -575,7 +575,7 @@ $ZPLUG_HOME
 .RE
 .\}
 .sp
-If you specify \fIas:command\fR when registering the package, zplug will recognize the plugin as a command and create a symbolic link of the same name (if you want to rename it, use rename_to) in $ZPLUG_HOME/bin\&. Because zplug adds $ZPLUG_HOME/bin to the $PATH, you can run that command from anywhere just like any other commands\&.
+If you specify \fIas:command\fR when registering the package, zplug will recognize the plugin as a command and create a symbolic link of the same name (if you want to rename it, use rename-to) in $ZPLUG_HOME/bin\&. Because zplug adds $ZPLUG_HOME/bin to the $PATH, you can run that command from anywhere just like any other commands\&.
 .PP
 \fIZPLUG_THREADS\fR
 .RS 4
@@ -686,11 +686,11 @@ zplug "tcnksm/docker\-alias", use:zshrc
 zplug "k4rthik/git\-cal", as:command, frozen:1
 
 # Grab binaries from GitHub Releases
-# and rename using the "rename_to:" tag
+# and rename using the "rename-to:" tag
 zplug "junegunn/fzf\-bin", \e
     as:command, \e
     from:gh\-r, \e
-    rename_to:fzf, \e
+    rename-to:fzf, \e
     use:"*darwin*amd64*"
 
 # Support oh\-my\-zsh plugins and the like
@@ -725,7 +725,7 @@ zplug "b4b4r07/hello_bitbucket", \e
 zplug "stedolan/jq", \e
     as:command, \e
     from:gh\-r \e
-    rename_to:jq, \e
+    rename-to:jq, \e
     on:"b4b4r07/emoji\-cli"
 
 # Set priority to load command like a nice command

--- a/doc/zplug.txt
+++ b/doc/zplug.txt
@@ -127,7 +127,7 @@ and so on
 
 |*at* | Branch, tag, or commit to use | *branch/tag* (`master`) | `at:v1.5.6`
 
-|*rename_to* | Specify the filename you want to rename to (only valid with `as:command`) | *filename* (-) | `rename_to:fzf`
+|*rename-to* | Specify the filename you want to rename to (only valid with `as:command`) | *filename* (-) | `rename-to:fzf`
 
 |*dir* | Installation directory which is managed by zplug | **READ ONLY** | `dir:/path/to/user/repo`
 
@@ -186,7 +186,7 @@ $ZPLUG_HOME
 
 If you specify 'as:command' when registering the package, zplug will recognize the plugin
 as a command and create a symbolic link of the same name (if you want to rename it,
-use `rename_to`) in `$ZPLUG_HOME/bin`. Because zplug adds `$ZPLUG_HOME/bin` to
+use `rename-to`) in `$ZPLUG_HOME/bin`. Because zplug adds `$ZPLUG_HOME/bin` to
 the `$PATH`, you can run that command from anywhere just like any other commands.
 
 'ZPLUG_THREADS'::
@@ -270,11 +270,11 @@ zplug "tcnksm/docker-alias", use:zshrc
 zplug "k4rthik/git-cal", as:command, frozen:1
 
 # Grab binaries from GitHub Releases
-# and rename using the "rename_to:" tag
+# and rename using the "rename-to:" tag
 zplug "junegunn/fzf-bin", \
     as:command, \
     from:gh-r, \
-    rename_to:fzf, \
+    rename-to:fzf, \
     use:"*darwin*amd64*"
 
 # Support oh-my-zsh plugins and the like
@@ -309,7 +309,7 @@ zplug "b4b4r07/hello_bitbucket", \
 zplug "stedolan/jq", \
     as:command, \
     from:gh-r \
-    rename_to:jq, \
+    rename-to:jq, \
     on:"b4b4r07/emoji-cli"
 
 # Set priority to load command like a nice command

--- a/src/completions/_zplug
+++ b/src/completions/_zplug
@@ -93,7 +93,7 @@ case "$words[1]" in
             "use[Specify the pattern to source (for plugin) or relative path to export (for command)]:use:->use" \
             "from[Specify the services you use to install]:from:(gh-r gist oh-my-zsh github bitbucket local)" \
             "at[Support branch/tag installation]:at:" \
-            "rename_to[Specify filename you want to rename]:rename_to:" \
+            "rename-to[Specify filename you want to rename]:rename-to:" \
             "dir[Installation directory (RO)]:dir:->dir" \
             "if[Specify the conditions under which to source or add to \$PATH]:if:" \
             "do[Run commands after installation/update]:do:" \


### PR DESCRIPTION
I managed to make the title consist of only two words! :wink: 

Since `hook-build` and `hook-load` both use a hyphen rather than an underscore, `rename_to` is also changed to `rename-to` to follow this naming convention.

@b4b4r07 I am not sure if the second `rename-to` in the following line should be `rename_to` or `rename-to` is fine. I read the zsh documentations on `_values` and it sounded like it's just describing the argument, so my guess was that it's okay for it to be `rename-to`, but could you check to make sure just in case?

https://github.com/NigoroJr/zplug/commit/77a5aa9cdd251b493be10176fb747400a988b49c#diff-3a82ca4b1fcbccf2b113ff0c4f02e94bR96