### PR TITLE
Fix init.zsh in current directory being sourced

### DIFF
--- a/zplug
+++ b/zplug
@@ -62,9 +62,8 @@ __get_zplug() {
     fi
 }
 
+local init_file="${${(%):-%N}:A:h}/init.zsh"
 function() {
-    local init_file="${${(%):-%N}:A:h}/init.zsh"
-
     if [[ -z $ZSH_VERSION ]]; then
         printf "[zplug] zplug must be run on ZSH\n" >&2
         return 1 2>&- || exit 1


### PR DESCRIPTION
This is due to the expansion `${(%):-%N}` done in an anonymous function.
Fixes #125.

```console
% function() {
    echo ${${(%):-%N}:A:h}
}
# Shows PWD
```