### PR TITLE
Change default value of ZPLUG_LOADFILE

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ Defaults to `fzf-tmux:fzf:peco:percol:zaw`. When `--select` option is specified,
 
 #### `ZPLUG_LOADFILE`
 
-Defaults to `$ZPLUG_HOME/init.zsh`. This file is used to add plugins from zplug on the command-line. It is also a useful place to isolate your packages list from `.zshrc`. Rather than cluttering your `.zshrc` with many lines enumerating packages, you can put them in a separate file and set `ZPLUG_LOADFILE` to its path.
+Defaults to `$ZPLUG_HOME/packages.zsh`. This file is used to add plugins from zplug on the command-line. It is also a useful place to isolate your packages list from `.zshrc`. Rather than cluttering your `.zshrc` with many lines enumerating packages, you can put them in a separate file and set `ZPLUG_LOADFILE` to its path.
 
 #### `ZPLUG_USE_CACHE`
 

--- a/doc/zplug.txt
+++ b/doc/zplug.txt
@@ -211,7 +211,7 @@ the `$PATH`, you can run that command from anywhere just like any other commands
     The `ZPLUG_FILTER` also accepts arguments (e.g. `fzf-tmux -d "10%":/path/to/peco:my peco`).
 
 'ZPLUG_LOADFILE'::
-    Defaults to `$ZPLUG_HOME/init.zsh`.
+    Defaults to `$ZPLUG_HOME/packages.zsh`.
     This file is used to add packages from zplug on the command-line. This is a
     useful feature when you want to isolate your zplug configurations from your
     `.zshrc`. Note that you don't need to add packages from the command line to

--- a/lib/zplug/variables.zsh
+++ b/lib/zplug/variables.zsh
@@ -10,7 +10,7 @@ typeset -gx ZPLUG_THREADS=${ZPLUG_THREADS:-16}
 typeset -gx ZPLUG_CLONE_DEPTH=${ZPLUG_CLONE_DEPTH:-0}
 typeset -gx ZPLUG_PROTOCOL=${ZPLUG_PROTOCOL:-HTTPS}
 typeset -gx ZPLUG_FILTER=${ZPLUG_FILTER:-"fzf-tmux:fzf:peco:percol:zaw"}
-typeset -gx ZPLUG_LOADFILE=${ZPLUG_LOADFILE:-$ZPLUG_HOME/init.zsh}
+typeset -gx ZPLUG_LOADFILE=${ZPLUG_LOADFILE:-$ZPLUG_HOME/packages.zsh}
 typeset -gx ZPLUG_USE_CACHE=true
 typeset -gx ZPLUG_CACHE_FILE=${ZPLUG_CACHE_FILE:-$ZPLUG_HOME/.cache}
 


### PR DESCRIPTION
The value is changed from `$ZPLUG_HOME/init.zsh` to `$ZPLUG_HOME/packages.zsh` to
avoid name collision with the code base.