### PR TITLE
Move a declaration of init.zsh path into a function

### DIFF
--- a/zplug
+++ b/zplug
@@ -62,8 +62,8 @@ __get_zplug() {
     fi
 }
 
-local init_file="${${(%):-%N}:A:h}/init.zsh"
 function() {
+    local init_file="${${(%):-%x}:A:h}/init.zsh"
     if [[ -z $ZSH_VERSION ]]; then
         printf "[zplug] zplug must be run on ZSH\n" >&2
         return 1 2>&- || exit 1


### PR DESCRIPTION
Moved from b4b4r07/zplug2#26.
Improvement for a64c511324bf561ba3881849ce6917b65c049c6d.

`${(%):-%x}` is always expanded into the script name.