### PR TITLE
Add external source for from:local

### DIFF
--- a/autoload/commands/__load__
+++ b/autoload/commands/__load__
@@ -116,9 +116,12 @@ do
             if __zplug::core::core::is_handler_defined load_command "$zspec[from]"; then
                 __zplug::core::core::use_handler load_command "$zspec[from]" "$key"
 
-                reply_hash=( ${(@f)reply} )
+                reply_hash=( $reply )
                 load_fpaths+=( ${(@f)reply_hash[load_fpaths]} )
-                load_commands+=( ${(@f)reply_hash[load_commands]} )
+                for pair in ${(@f)reply_hash[load_commands]}; do
+                    # Each line (pair) is null character-separated
+                    load_commands+=( ${(@s:\0:)pair} )
+                done
             else
                 basename="${zspec[name]:t}"
                 zspec[dir]="${zspec[dir]%/}"
@@ -239,18 +242,6 @@ do
                         fi
                     fi
                 done
-
-                if [[ $zspec[nice] -gt 9 ]]; then
-                    # the order of loading of plugin files
-                    nice_plugins+=( "${load_patterns[@]}" )
-                else
-                    # autoload plugin / regular plugin
-                    if (( $__zplug_boolean_true[(I)$zspec[lazy]] )); then
-                        lazy_plugins+=( "${load_patterns[@]}" )
-                    else
-                        load_plugins+=( "${load_patterns[@]}" )
-                    fi
-                fi
             fi
             ;;
 
@@ -259,6 +250,20 @@ do
             return 1
             ;;
     esac
+
+    if [[ $zspec[as] == plugin ]]; then
+        if [[ $zspec[nice] -gt 9 ]]; then
+            # the order of loading of plugin files
+            nice_plugins+=( "${load_patterns[@]}" )
+        else
+            # autoload plugin / regular plugin
+            if (( $__zplug_boolean_true[(I)$zspec[lazy]] )); then
+                lazy_plugins+=( "${load_patterns[@]}" )
+            else
+                load_plugins+=( "${load_patterns[@]}" )
+            fi
+        fi
+    fi
 
     if [[ -n $zspec[ignore] ]]; then
         # Make ignore patterns

--- a/src/ext/local.zsh
+++ b/src/ext/local.zsh
@@ -26,7 +26,7 @@ __zplug::local::load_plugin() {
         load_patterns+=( "${~zspec[name]}" )
     elif [[ -d ${~zspec[name]} ]]; then
         if [[ -n $zspec[use] ]]; then
-            load_patterns+=( $(zsh -c "echo $zspec[name]/$zspec[use]") )
+            load_patterns+=( $(zsh -c "echo $zspec[name]/$zspec[use]" 2>/dev/null) )
         else
             load_fpaths+=(
                 ${~zspec[name]}/{_*,**/_*}(N-.:h)
@@ -58,10 +58,10 @@ __zplug::local::load_command() {
     if [[ -f ${~zspec[name]} ]]; then
         # Expand special characters such as ~ to $HOME
         # echo "${~foo}" with the double quotes doesn't expand for some reason
-        load_commands+=( "$(zsh -c "echo ${zspec[name]}")" )
+        load_commands+=( "$(zsh -c "echo ${zspec[name]}" 2>/dev/null)" )
     elif [[ -d ${~zspec[name]} ]]; then
         if [[ -n $zspec[use] ]]; then
-            load_commands+=( $(zsh -c "echo $zspec[name]/$zspec[use]") )
+            load_commands+=( $(zsh -c "echo $zspec[name]/$zspec[use]" 2>/dev/null) )
         else
             load_fpaths+=( ${~zspec[name]}(N-.) )
         fi

--- a/src/ext/local.zsh
+++ b/src/ext/local.zsh
@@ -53,7 +53,7 @@ __zplug::local::load_command() {
     local -a load_commands
     local dst
 
-    dst=${${zspec[rename-to]:+$ZPLUG_HOME/bin/$zspec[rename-to]}:-"$ZPLUG_HOME/bin"}
+    dst=${${zspec[rename_to]:+$ZPLUG_HOME/bin/$zspec[rename_to]}:-"$ZPLUG_HOME/bin"}
 
     if [[ -f ${~zspec[name]} ]]; then
         # Expand special characters such as ~ to $HOME

--- a/src/ext/local.zsh
+++ b/src/ext/local.zsh
@@ -1,0 +1,94 @@
+#!/bin/zsh
+
+__zplug::local::check() {
+    local    line
+    local -A zspec
+
+    line="$1"
+    __parser__ "$line"
+    zspec=( "${reply[@]}" )
+
+    [[ -e ${~zspec[name]} ]]
+}
+
+__zplug::local::load_plugin() {
+    local    line
+    local -A zspec
+
+    line="$1"
+    __parser__ "$line"
+    zspec=( "${reply[@]}" )
+
+    local -a load_patterns
+    local -a load_fpaths
+
+    if [[ -f ${~zspec[name]} ]]; then
+        load_patterns+=( "${~zspec[name]}" )
+    elif [[ -d ${~zspec[name]} ]]; then
+        if [[ -n $zspec[use] ]]; then
+            load_patterns+=( $(zsh -c "echo $zspec[name]/$zspec[use]") )
+        else
+            load_fpaths+=(
+                ${~zspec[name]}/{_*,**/_*}(N-.:h)
+            )
+        fi
+    fi
+
+    reply=()
+    [[ -n $load_fpaths ]] && reply+=( load_fpaths "${(F)load_fpaths}" )
+    [[ -n $load_patterns ]] && reply+=( load_patterns "${(F)load_patterns}" )
+
+    return 0
+}
+
+__zplug::local::load_command() {
+    local    line
+    local -A zspec
+
+    line="$1"
+    __parser__ "$line"
+    zspec=( "${reply[@]}" )
+
+    local -a load_fpaths
+    local -a load_commands
+    local dst
+
+    dst=${${zspec[rename-to]:+$ZPLUG_HOME/bin/$zspec[rename-to]}:-"$ZPLUG_HOME/bin"}
+
+    if [[ -f ${~zspec[name]} ]]; then
+        # Expand special characters such as ~ to $HOME
+        # echo "${~foo}" with the double quotes doesn't expand for some reason
+        load_commands+=( "$(zsh -c "echo ${zspec[name]}")" )
+    elif [[ -d ${~zspec[name]} ]]; then
+        if [[ -n $zspec[use] ]]; then
+            load_commands+=( $(zsh -c "echo $zspec[name]/$zspec[use]") )
+        else
+            load_fpaths+=( ${~zspec[name]}(N-.) )
+        fi
+    fi
+
+    # Append dst to each element so that load_commands becomes:
+    #
+    # load_commands=(
+    #   path/to/cmd1\0dst
+    #   path/to/cmd2\0dst
+    #   ...
+    # )
+    #
+    # where \0 is a null character used to separate the two strings.
+    #
+    # In the caller function (__load__), each line is decomposed into an
+    # element in an associative array, thus, in the example above, the line:
+    #
+    #   path/to/cmd1\0dst
+    #
+    # becomes an element where the key is "path/to/cmd" and the value is
+    # "dst".
+    load_commands=( ${^load_commands}"\0$dst" )
+
+    reply=()
+    [[ -n $load_fpaths ]] && reply+=( load_fpaths "${(F)load_fpaths}" )
+    [[ -n $load_commands ]] && reply+=( load_commands "${(F)load_commands}" )
+
+    return 0
+}

--- a/src/ext/local.zsh
+++ b/src/ext/local.zsh
@@ -62,9 +62,9 @@ __zplug::local::load_command() {
     elif [[ -d ${~zspec[name]} ]]; then
         if [[ -n $zspec[use] ]]; then
             load_commands+=( $(zsh -c "echo $zspec[name]/$zspec[use]" 2>/dev/null) )
-        else
-            load_fpaths+=( ${~zspec[name]}(N-.) )
         fi
+
+        load_fpaths+=( ${~zspec[name]}{_*,/**/_*}(N-.:h) )
     fi
 
     # Append dst to each element so that load_commands becomes:


### PR DESCRIPTION
This PR fixes some of the bugs in the external source feature and separates `from:local`. Checked with the following:

```zsh
# Files
zplug '~/a.zsh', from:local
zplug '~/b.zsh', from:local, as:command
zplug '~/c.zsh', from:local, as:command, rename_to:foo
# Directories
zplug '~/tmp', from:local
zplug '~/tmp', from:local, as:command, use:a.zsh
```