### PR TITLE
Deprecate clear --force

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Finally, use `zplug install` to install your plugins and reload `.zshrc`.
 | `check`   | Return true all packages are installed, false otherwise | `--verbose` |
 | `status`  | Check if the remote repositories are up to date | `--select` |
 | `clean`   | Remove repositories which are no longer managed | `--force`,`--select` |
-| `clear`   | Remove the cache file | `--force` |
+| `clear`   | Remove the cache file | (None) |
 | `info`    | Show the information such as the source URL and tag values for the given package | (None) |
 
 ## Options for `zplug`

--- a/autoload/commands/__clear__
+++ b/autoload/commands/__clear__
@@ -2,15 +2,12 @@
 
 __import "print/print"
 
-local arg is_force
+local arg
 
 while (( $# > 0 ))
 do
     arg="$1"
     case "$arg" in
-        --force)
-            is_force=true
-            ;;
         -*|--*)
             __zplug::print::print::die "[zplug] $arg: Unknown option\n"
             return 1
@@ -19,9 +16,4 @@ do
     shift
 done
 
-if eval ${is_force:-"__zplug::print::print::put 'Remove cache file? ';read -q;__zplug::print::print::put '\n'"}; then
-    rm -f "$ZPLUG_CACHE_FILE"
-    __zplug::print::print::put "Removed\n"
-else
-    __zplug::print::print::put "Canceled\n"
-fi
+rm -f "$ZPLUG_CACHE_FILE"

--- a/doc/man/man1/zplug.1
+++ b/doc/man/man1/zplug.1
@@ -2,12 +2,12 @@
 .\"     Title: zplug
 .\"    Author: Masaki Ishiyama (@b4b4r07) b4b4r07@gmail.com
 .\" Generator: DocBook XSL Stylesheets v1.79.0 <http://docbook.sf.net/>
-.\"      Date: 02/28/2016
+.\"      Date: 04/02/2016
 .\"    Manual: ZPLUG Manual
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "ZPLUG" "1" "02/28/2016" "\ \&" "ZPLUG Manual"
+.TH "ZPLUG" "1" "04/02/2016" "\ \&" "ZPLUG Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -258,11 +258,9 @@ $ZPLUG_FILTER, interactively select the
 you want to uninstall\&.
 .RE
 .PP
-\fBclear\fR [\-\-force]
+\fBclear\fR
 .RS 4
-Refresh the cache file\&.
-\-\-force
-does the same as what\(cqs described above\&.
+Remove the cache file\&.
 .RE
 .PP
 \fBinstall\fR [\-\-verbose] [\-\-select] [\fIpackage\fR]

--- a/doc/zplug.txt
+++ b/doc/zplug.txt
@@ -68,9 +68,8 @@ COMMANDS
     If the `--select` option is given, by using the filter specified in
     `$ZPLUG_FILTER`, interactively select the 'package' you want to uninstall.
 
-*clear* [--force]::
-    Refresh the cache file.
-    `--force` does the same as what's described above.
+*clear*::
+    Remove the cache file.
 
 *install* [--verbose] [--select] ['package']::
     Install 'package'.


### PR DESCRIPTION
Since there is not much point in prompting (i.e. it's not the end of the world
if you delete your cache by mistake), the default behavior becomes the
equivalent of `--force` but without the message.