### PR TITLE
Automatically set executable permissions on commands

### DIFF
--- a/autoload/commands/__load__
+++ b/autoload/commands/__load__
@@ -302,7 +302,7 @@ done
     for f in "${(k)load_commands[@]}"
     do
         if [[ -f $f ]]; then
-            ln -snf "$f" "$load_commands[$f]"
+            chmod a=rx "$f" && ln -snf "$f" "$load_commands[$f]"
             if (( $status != 0 )); then
                 failed_packages+=("$f")
             fi


### PR DESCRIPTION
Avoid having to have `do:"chmod a=rx *"` on every `as:command` entry.

Signed-off-by: Daniel Bayley <daniel.bayley@me.com>