### PR TITLE
Fix hook-build and hook-load not evaluated

### DIFF
--- a/autoload/commands/__load__
+++ b/autoload/commands/__load__
@@ -293,10 +293,10 @@ do
     fi
 
     # hook after load
-    if [[ -n $zspec[hook_load] ]]; then
+    if [[ -n $zspec[hook-load] ]]; then
         hook_load+=(
             "$zspec[name]"
-            "$zspec[hook_load]"
+            "$zspec[hook-load]"
         )
     fi
 done

--- a/autoload/commands/__update__
+++ b/autoload/commands/__update__
@@ -157,8 +157,8 @@ do
                     $SECONDS
 
                 # hook after updating
-                if [[ -n $zspec[hook_build] ]]; then
-                    eval "$zspec[hook_build]"
+                if [[ -n $zspec[hook-build] ]]; then
+                    eval "$zspec[hook-build]"
                 fi
                 ;;
             1)

--- a/src/completions/_zplug
+++ b/src/completions/_zplug
@@ -96,7 +96,8 @@ case "$words[1]" in
             "rename-to[Specify filename you want to rename]:rename-to:" \
             "dir[Installation directory (RO)]:dir:->dir" \
             "if[Specify the conditions under which to source or add to \$PATH]:if:" \
-            "do[Run commands after installation/update]:do:" \
+            "hook-build[Commands to run after installation/update]:hook-build:" \
+            "hook-load[Commands to run after loading]:hook-load:" \
             "frozen[Do not update unless explicitly specified]:frozen:->boolean" \
             "on[Dependencies (RO)]:on:->on" \
             "nice[Priority of loading the plugins]:nice:->nice" \


### PR DESCRIPTION
This is due to `$zspec[hook_build]` being used when the correct key is
`$zspec[hook-build]` (with a hyphen).

Checked with:

```zsh
zplug 'zsh-users/zsh-syntax-highlighting', \
    hook-build:"echo 'build'", \
    hook-load:"echo 'load'"
```