### PR TITLE
Move assignment from load_patterns into case statement

### DIFF
--- a/autoload/commands/__load__
+++ b/autoload/commands/__load__
@@ -248,6 +248,18 @@ do
                     fi
                 done
             fi
+
+            if [[ $zspec[nice] -gt 9 ]]; then
+                # the order of loading of plugin files
+                nice_plugins+=( "${load_patterns[@]}" )
+            else
+                # autoload plugin / regular plugin
+                if (( $__zplug_boolean_true[(I)$zspec[lazy]] )); then
+                    lazy_plugins+=( "${load_patterns[@]}" )
+                else
+                    load_plugins+=( "${load_patterns[@]}" )
+                fi
+            fi
             ;;
 
         *)
@@ -255,20 +267,6 @@ do
             return 1
             ;;
     esac
-
-    if [[ $zspec[as] == plugin ]]; then
-        if [[ $zspec[nice] -gt 9 ]]; then
-            # the order of loading of plugin files
-            nice_plugins+=( "${load_patterns[@]}" )
-        else
-            # autoload plugin / regular plugin
-            if (( $__zplug_boolean_true[(I)$zspec[lazy]] )); then
-                lazy_plugins+=( "${load_patterns[@]}" )
-            else
-                load_plugins+=( "${load_patterns[@]}" )
-            fi
-        fi
-    fi
 
     if [[ -n $zspec[ignore] ]]; then
         # Make ignore patterns


### PR DESCRIPTION
Even though this is a cosmetic change, it makes the scope of the variable less
confusing. The `load_patterns` variable is only used in the `"plugin"` case of the
case statement, but used outside of the case statement.