### PR TITLE
Fix zplug update not updating packages

### DIFF
--- a/autoload/commands/__update__
+++ b/autoload/commands/__update__
@@ -116,11 +116,11 @@ do
                     --at  "${zspec[at]:-}" \
                     "$line"
             else
-                local fetch_opt
                 if [[ -e $zspec[dir]/.git/shallow ]]; then
-                    fetch_opt="--unshallow"
+                    git fetch --unshallow
+                else
+                    git fetch
                 fi
-                git fetch "$fetch_opt"
                 git checkout -q "$zspec[at]"
 
                 local rev_local rev_remote rev_base


### PR DESCRIPTION
This is due to an error in git fetch which is ignored because of stderr
redirected to /dev/null. The error can be confirmed with:

    $ git fetch ""

which results in the output:

    fatal: No path specified. See 'man git-pull' for valid url syntax

Fixes #141.