### PR TITLE
Fix error in printf when running zplug status

### DIFF
--- a/autoload/commands/__status__
+++ b/autoload/commands/__status__
@@ -40,6 +40,8 @@ esac
             line="$(__zplug::core::core::packaging "$line")"
             (( $#line > $max )) && max=$#line
         done
+        max=$(( $max + 1 ))
+
         __zplug::print::print::put "Fetching the status of packages ...\n"
         __zplug::print::print::put "Packages with from:'local' are skipped.\n"
         __zplug::print::print::put "===\n"


### PR DESCRIPTION
This is due to `%0s` used for specifying the width. When running `zplug status`, error messages like the following is shown:

```
rimraf/k                          (up to date) 'https://git::@github.com/rimraf/k.git'
zsh-users/zsh-syntax-highlightingprintf: %0s: invalid conversion specification
junegunn/fzf-bin                  (up to date) 'https://github.com/junegunn/fzf-bin/releases'
```