### PR TITLE
Ignore plugin installation folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ bin/*
 **/*~
 **/*.swp
 .cache
+repos/


### PR DESCRIPTION
I think the default installation folder of plugins (`$ZPLUG_HOME/repos`) should be registered in `.gitignore`.